### PR TITLE
11 drop the f switch

### DIFF
--- a/lib/serverprint.pl
+++ b/lib/serverprint.pl
@@ -22,8 +22,7 @@ my $additional_opts = "";
 
 sub help_text {
   print "Usage: \n",
-  "serverprint -p Printer -s Server -f File -n NoOfCopies -c -o '-o sides=two-sided-long-edge'\n",
-  "  -f is the file to printed. The file can also be provided without the switch\n",
+  "serverprint -p Printer -s Server -n NoOfCopies -c -o '-o sides=two-sided-long-edge' path/to/printeable-file.pdf\n",
   "  -p is the name of the printer as identified by cups/lpq (default: 'Stuga')\n",
   "  -s should be a server-reference processable by ssh, preferably a config-host (default: 'stuga')\n",
   "  -c asks for automatic file conversions if the printing is likely to trigger problems(default: on)\n",
@@ -182,15 +181,15 @@ sub die_hard {
   exit $exit_state;
 }
 
-# -o, -f, -p, -n, & -s take arguments. Values can be found in %opts
-GetOptions(\%opts, 'o=s', 'f=s', 'p=s', 's=s', 'n=i', 'c|convert!',
+# -o, -p, -n, & -s take arguments. Values can be found in %opts
+GetOptions(\%opts, 'o=s', 'p=s', 's=s', 'n=i', 'c|convert!',
   'd', 'h|help',
   'two-sided' => \$opts{two_sided},
   'one-sided' => sub { $opts{two_sided} = 0 },
   'no-side' => sub { $opts{no_side} = 1 },
   'pages-per-print-page=i' => \&print_pages_handler);
 
-my $filepath = $opts{f} || $ARGV[0];
+my $filepath = $ARGV[0];
 
 die help_text if $opts{h} || !$filepath;
 if ($opts{o}) {

--- a/share/man/man1/serverprint.1
+++ b/share/man/man1/serverprint.1
@@ -8,13 +8,12 @@
 .
 .Sh SYNOPSIS
 .Nm
-. Op Pa file/to/be/printed.pdf
 . Op Fl p Ar printername
 . Op Fl s Ar servername
 . Op Fl n Ar number-of-copies
 . Op Fl c
 . Op Fl o Qq lpr-options
-. Fl f Pa file/to/be/printed.pdf
+. Pa file/to/be/printed.pdf
 .
 .Sh DESCRIPTION
 .Nm
@@ -22,9 +21,6 @@ allows you print files to a remote printer over a ssh-connection
 .
 .Sh OPTIONS
 .Bl -tag
-. It Fl f Pa file/to/be/printed.pdf
-.  No The path to the actual file that is supposed to be printed.
-.
 . It Fl c Ns , Fl Fl convert
 .  No is activated by default (so providing -c is basically a no-op).
 .  No Converts the given (PDF-)file if appropriate.


### PR DESCRIPTION
Shall close #11.

Basically does not remove `-f` but amends the usage in order to make the switch optional.
